### PR TITLE
fix: sheet is too small, or might be displayed on the wrong window

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,6 @@ Contributions are welcome. File issues to the [GitHub repo](https://github.com/C
 * [Similarly to `image_picker_macos`](https://pub.dev/packages/image_picker_macos#limitations), `ImageSource.camera` is not supported [unless a `cameraDelegate` is set](https://pub.dev/packages/image_picker#windows-macos-and-linux).
 * [Similarly to `image_picker_macos`](https://pub.dev/packages/image_picker_macos#pickvideo), the `maxDuration` argument in `pickVideo` is unsupported and will be silently ignored.
 
-> [!WARNING]
-> **Known issue**: The native picker window initially appears smaller than expected, requiring the user to manually resize it. Refer to [#2](https://github.com/CompileKernel/native-image-picker-macos/issues/2) for details.
-
 ## 📚 Additional information
 
 This functionality was originally proposed as a [pull request to `image_picker_macos`](https://github.com/flutter/packages/pull/8079/), but it was later decided to split it into a community package which is unendorsed.

--- a/macos/native_image_picker_macos/Sources/native_image_picker_macos/ImagePickerImpl.swift
+++ b/macos/native_image_picker_macos/Sources/native_image_picker_macos/ImagePickerImpl.swift
@@ -118,14 +118,8 @@ class ImagePickerImpl: NSObject, ImagePickerApi {
       return
     }
 
-    let windowSize = window.frame.size
-
-    let scaleFactor = 0.80  // 80% of the parent window's size
-
-    var pickerWidth = windowSize.width * scaleFactor
-    var pickerHeight = windowSize.height * scaleFactor
-
-    picker.view.frame = NSRect(x: 0, y: 0, width: pickerWidth, height: pickerHeight)
+    // A similar initial sheet size to PhotosPicker in a macOS SwiftUI app.
+    picker.view.frame = NSRect(x: 0, y: 0, width: 780, height: 615)
 
     window.contentViewController?.presentAsSheet(picker)
 

--- a/macos/native_image_picker_macos/Sources/native_image_picker_macos/ImagePickerImpl.swift
+++ b/macos/native_image_picker_macos/Sources/native_image_picker_macos/ImagePickerImpl.swift
@@ -128,6 +128,9 @@ class ImagePickerImpl: NSObject, ImagePickerApi {
     picker.view.frame = NSRect(x: 0, y: 0, width: pickerWidth, height: pickerHeight)
 
     window.contentViewController?.presentAsSheet(picker)
+
+    // A similar minimum sheet size to PhotosPicker in a macOS SwiftUI app.
+    picker.view.window?.contentMinSize = NSSize(width: 320, height: 200)
   }
 
   func openPhotosApp() -> Bool {

--- a/macos/native_image_picker_macos/Sources/native_image_picker_macos/ImagePickerImpl.swift
+++ b/macos/native_image_picker_macos/Sources/native_image_picker_macos/ImagePickerImpl.swift
@@ -8,6 +8,12 @@ import PhotosUI
 /// to use [PHPickerViewController](https://developer.apple.com/documentation/photokit/phpickerviewcontroller) which is supported on macOS 13.0+
 /// otherwise fallback to file selector if unsupported or the user prefers the file selector implementation.
 class ImagePickerImpl: NSObject, ImagePickerApi {
+  private let view: NSView?
+
+  init(view: NSView?) {
+    self.view = view
+  }
+
   /// Returns `true` if the current macOS version supports this feature.
   ///
   /// `PHPicker` is supported on macOS 13.0+.
@@ -107,11 +113,20 @@ class ImagePickerImpl: NSObject, ImagePickerApi {
   @available(macOS 13, *)
   private func showPHPicker(_ picker: PHPickerViewController, noActiveWindow: @escaping () -> Void)
   {
-    guard let window = NSApplication.shared.keyWindow else {
+    guard let window = view?.window else {
       noActiveWindow()
       return
     }
-    // TODO(EchoEllet): IMPORTANT The window size of the picker is smaller than expected, see the video in https://discord.com/channels/608014603317936148/1295165633931120642/1295470850283147335
+
+    let windowSize = window.frame.size
+
+    let scaleFactor = 0.80  // 80% of the parent window's size
+
+    var pickerWidth = windowSize.width * scaleFactor
+    var pickerHeight = windowSize.height * scaleFactor
+
+    picker.view.frame = NSRect(x: 0, y: 0, width: pickerWidth, height: pickerHeight)
+
     window.contentViewController?.presentAsSheet(picker)
   }
 

--- a/macos/native_image_picker_macos/Sources/native_image_picker_macos/NativeImagePickerPlugin.swift
+++ b/macos/native_image_picker_macos/Sources/native_image_picker_macos/NativeImagePickerPlugin.swift
@@ -4,7 +4,7 @@ import FlutterMacOS
 public class NativeImagePickerPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let messenger = registrar.messenger
-    let api = ImagePickerImpl()
+    let api = ImagePickerImpl(view: registrar.view)
     ImagePickerApiSetup.setUp(binaryMessenger: messenger, api: api)
   }
 }

--- a/pigeons/messages.dart
+++ b/pigeons/messages.dart
@@ -66,6 +66,7 @@ enum ImagePickerError {
   phpickerUnsupported,
 
   /// Could not show the picker due to the missing window.
+  /// This May occur if the `NSView` is `nil`, for instance in a headless environment.
   windowNotFound,
 
   /// When a `PHPickerResult` can't load `NSImage`. This error should not be reached


### PR DESCRIPTION
Fixing:
- *#4*
- *#2*

Currently, the `ImagePickerImpl.swift` coverage is low but tests are planned and will be added (#6) before working on new features (e.g., #5).

The Swift code will be refactored to be testable and we may refer to [`file_selector`](https://github.com/flutter/packages/blob/e8f1f63bc3b75a5bea33eb6b07226c4b140a24d0/packages/file_selector/file_selector_macos/macos/file_selector_macos/Sources/file_selector_macos/FileSelectorPlugin.swift#L177-L178) during the process.

https://github.com/user-attachments/assets/e9072032-06dc-4812-9864-c8ffe2022d94

